### PR TITLE
Fix usage of deprecated fetch method

### DIFF
--- a/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
+++ b/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php
@@ -532,7 +532,7 @@ CREATE\sTABLE # Match "CREATE TABLE"
 
     private function getCreateTableSQL(string $table): ?string
     {
-        return $this->_conn->fetchColumn(
+        return $this->_conn->fetchOne(
             <<<'SQL'
 SELECT sql
   FROM (


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

When upgrading a library to 2.13 and trying to fix all the deprecations, this always came up in the results. I've replaced the deprecated fetch method so the internal code doesn't have any "self deprecations"